### PR TITLE
Release 1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,108 @@
+# HTML Page Sitemap Changelog
+[HTML Page Sitemap](https://www.pluginspodcast.com/plugins/html-page-sitemap/) WordPress plugin.
+
+All notable changes to this project will be documented in this file.
+
+**Keep a Changelog**
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Each version section should start with a H2 (`## `), the version number in hard brackets, a space-dash-space (` - `), 
+and the release date in ISO date format (ISO 8601), *YYYY-MM-DD*.
+The proceeding line may contain 1 or more sentences describing the purpose of the release.
+A blank line is added to separate the heading/paragraph from the list of changes.
+Changes are listed, each item prefixed with a minus (-) character. Tabs may be used to indent the list.
+A blank line is added to separate the list from the next heading/paragraph.
+
+```markdown
+## [0.0.0] - 2025-01-02
+This is an example changelog entry.
+
+- Fixed this
+  - and this,
+  - and this
+  - and that
+- Added that
+- Removed other
+```
+
+**Semantic Versioning**
+This project adheres _somewhat_ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
+The first version of a MAJOR or MINOR release will exclude the second dot followed by zero (`.0`).
+For example `2.0` will be used rather than `2.0.0`. Otherwise Semantic Versioning is strictly followed.
+
+## [Unreleased]
+TBD
+
+## [1.3.7] - 2025-04-21
+
+- Tested with WordPress up to version 6.8
+- Added CHANGELOG.md
+
+## [1.3.6] - 2025-02-09
+
+- Tested with WordPress up to version 6.7.1
+- Project now managed on [GitHub](https://github.com/mandato-wordpress/html-sitemap)
+
+## [1.3.5] - N/A
+
+- Release skipped
+
+## [1.3.4] - 2024-08-13
+
+- Tested with WordPress up to version 6.6
+- Readme.txt updated to latest requirements (ref: https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/)
+
+## [1.3.3] - 2020-03-14
+
+- Tested with WordPress up to version 5.4
+
+## [1.3.2] - 2018-10-05
+
+- Fixed warning messages in PHP7 when modifying the $args value when it is not an array.
+
+## [1.3.1] - 2018-01-08
+
+- Added a blank index.php to root plugin folder for extra security.
+- Tested with WordPress up to version 4.9.1
+
+## [1.3] - 2015-11-24
+
+- Added `ordered_list_type` option to use an ordered list rather than unordered. (Thanks Allie for the feature suggestion!)
+- Tested with WordPress 4.4 beta 4
+
+## [1.2] - 2015-09-15
+
+- Tested with WordPress 4.3.
+- Added class and id attribute options for specifying HTML class and/or id attributes in the unordered list `<ul>`. (Thanks phorbidden for the feature suggestion!)
+- Updated readme, added additional examples for the class and id attribute options.
+
+## [1.1.4] - 2015-01-11
+
+- Tested with WordPress 4.1.
+- End of source no longer includes closing PHP tag as recommended by WordPress.
+- Updated readme, added additional example excluding multipe pages.
+
+## [1.1.3] - 2013-03-11
+
+- HTML Sitemap compatible with latest versions of WordPress up to 3.5.1
+- Nothing has changed with this plugin other than the readme.txt.
+
+## [1.1.2] - 2012-01-31
+
+- Hyphen in shortcode changed to underscore. `html_sitemap` and `htmlsitemap` shortcodes work.  [read more here](http://wordpress.org/support/topic/plugins-wont-coexist?replies=5)
+- HTML Sitemap compatible with latest versions of WordPress up to 3.3.1
+
+## [1.1.1] - 2010-06-27
+
+- HTML Sitemap compatible with latest versions of WordPress 2.9 and 3.0.
+
+## [1.1.0] - 2009-11-24
+
+- Fixed typos in readme
+- Added child_of options
+-- child_of=CURRENT (starts list of pages that are children of the current page)
+-- child_of=PARENT (starts list of pages that are of the same level as current page)
+
+## [1.0.0] - 2009-09-05
+
+- Initial release of HTML Page Sitemap plugin.

--- a/html-sitemap.php
+++ b/html-sitemap.php
@@ -3,12 +3,12 @@
 Plugin Name: HTML Page Sitemap
 Plugin URI: http://www.pluginspodcast.com/plugins/html-page-sitemap/
 Description: <a href="https://wordpress.org/plugins/html-sitemap/" target="_blank">HTML Page Sitemap</a> Adds an HTML (Not XML) sitemap of your blog pages (not posts) by entering the shortcode [html_sitemap]. A plugin from <a href="http://angelo.mandato.com/" target="_blank">Angelo Mandato</a>.
-Version: 1.3.6
+Version: 1.3.7
 Contributors: Angelo Mandato, Founder and CTO of [Painless Analytics](https://www.painlessanalytics.com)
 Author URI: http://angelo.mandato.com/
 
 Requires at least: 3.7
-Tested up to: 6.7.1
+Tested up to: 6.8
 Text Domain: html-sitemap
 Change Log: See readme.txt for complete change log
 Contributors: Angelo Mandato, Founder and CTO of Painless Analytics

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: amandato
 Donate link: http://angelo.mandato.com/contact/
 Tags: html sitemap, sitemap, page, pages, shortcode
 Requires at least: 2.7
-Tested up to: 6.7.1
-Stable tag: 1.3.6
+Tested up to: 6.8
+Stable tag: 1.3.7
 Requires PHP: 4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -108,82 +108,27 @@ Install using the [built-in plugin installer](https://codex.wordpress.org/Admini
 
 == Changelog ==
 
+= 1.3.7 =
+* Released on 2025-04-21
+* Tested with WordPress up to version 6.8
+* Complete changelog moved to CHANGELOG.md
+
 = 1.3.6 =
-* Released on 2/09/2025
+* Released on 2025-02-09
 * Tested with WordPress up to version 6.7.1
 * Project now managed on [GitHub](https://github.com/mandato-wordpress/html-sitemap)
-
 
 = 1.3.5 =
 * Release skipped
 
 = 1.3.4 =
-* Released on 8/13/2024
+* Released on 2024-08-13
 * Tested with WordPress up to version 6.6
 * Readme.txt updated to latest requirements (ref: https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/)
 
 
-= 1.3.3 =
-* Released on 3/14/2020
-* Tested with WordPress up to version 5.4
-
-
-= 1.3.2 =
-* Released on 10/05/2018
-* Fixed warning messages in PHP7 when modifying the $args value when it is not an array.
-
-
-= 1.3.1 =
-* Released on 1/8/2018
-* Added a blank index.php to root plugin folder for extra security.
-* Tested with WordPress up to version 4.9.1
-
-
-= 1.3 =
-* Released on 11/24/2015
-* Added `ordered_list_type` option to use an ordered list rather than unordered. (Thanks Allie for the feature suggestion!)
-* Tested with WordPress 4.4 beta 4
-
-
-= 1.2 =
-* Released on 9/15/2015
-* Tested with WordPress 4.3.
-* Added class and id attribute options for specifying HTML class and/or id attributes in the unordered list `<ul>`. (Thanks phorbidden for the feature suggestion!)
-* Updated readme, added additional examples for the class and id attribute options.
-
-
-= 1.1.4 =
-* Released on 1/11/2015
-* Tested with WordPress 4.1.
-* End of source no longer includes closing PHP tag as recommended by WordPress.
-* Updated readme, added additional example excluding multipe pages.
-
-
-= 1.1.3 =
-* Released 3/11/2013
-* HTML Sitemap compatible with latest versions of WordPress up to 3.5.1
-* Nothing has changed with this plugin other than the readme.txt.
-
-
-= 1.1.2 =
-* Released 1/31/2012
-* Hyphen in shortcode changed to underscore. `html_sitemap` and `htmlsitemap` shortcodes work.  [read more here](http://wordpress.org/support/topic/plugins-wont-coexist?replies=5)
-* HTML Sitemap compatible with latest versions of WordPress up to 3.3.1
-
-= 1.1.1 =
-* Released 6/27/2010
-* HTML Sitemap compatible with latest versions of WordPress 2.9 and 3.0.
-
-= 1.1.0 =
-* Released on 11/24/2009
-* Fixed typos in readme
-* Added child_of options
-** child_of=CURRENT (starts list of pages that are children of the current page)
-** child_of=PARENT (starts list of pages that are of the same level as current page)
-
-= 1.0.0 =
-* Released on 09/05/2009
-* Initial release of HTML Page Sitemap plugin.
+= Complete Changelog =
+[Complete changelog available on GitHub](https://github.com/mandato-wordpress/html-sitemap/blob/main/CHANGELOG.md)
 
 == Upgrade Notice ==
 None at this time.


### PR DESCRIPTION
- Released on 2025-04-21
- Tested with WordPress up to version 6.8
- Complete changelog moved to CHANGELOG.md