### PR TITLE
Release 2.1.1

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,7 @@
 /.wordpress-org
 /.git
 /.github
+/.kiro
 /node_modules
 /src
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Directories
 /.wordpress-org export-ignore
 /.github export-ignore
+/.kiro export-ignore
 
 # Files
 /.htaccess export-ignore

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,24 @@
+# Product Overview
+
+HTML Page Sitemap is a WordPress plugin that generates HTML sitemaps (not XML) for hierarchical pages using either a Gutenberg block or shortcode.
+
+## Core Functionality
+
+- Displays hierarchical page structure as nested HTML lists (`<ul>` or `<ol>`)
+- Supports both Block Editor (Gutenberg) and classic shortcode `[html_sitemap]`
+- Wraps WordPress core `wp_list_pages()` function with additional customization
+- Designed for WordPress-as-CMS use cases
+
+## Key Features
+
+- Depth control for nested pages
+- Include/exclude specific pages by ID
+- Filter by custom fields, authors, post status
+- Support for ordered/unordered lists with custom styling
+- Dynamic child_of values: CURRENT (current page) or PARENT (parent page)
+- Custom CSS class and ID attributes
+- Multiple sorting options (menu_order, post_title, post_date, etc.)
+
+## Target Users
+
+WordPress site administrators using WordPress as a CMS who need to display page hierarchies to visitors.

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,70 @@
+# Project Structure
+
+## Root Level Files
+
+- `html-sitemap.php` - Main plugin file with shortcode handler and plugin metadata
+- `html-sitemap-admin.class.php` - Admin functionality (block registration)
+- `index.php` - Security file (prevents directory listing)
+- `package.json` - npm dependencies and build scripts
+- `readme.txt` - WordPress.org plugin directory readme
+- `README.md` - GitHub repository readme
+- `CHANGELOG.md` - Complete version history
+- `LICENSE` - GPL license file
+
+## Directory Structure
+
+```
+/
+├── src/                          # Source files (not distributed)
+│   └── html-sitemap-block/       # Block editor component
+│       ├── block.json            # Block metadata and attributes
+│       ├── index.js              # Block registration entry point
+│       ├── edit.js               # Block editor UI component
+│       ├── save.js               # Block save function (dynamic render)
+│       ├── shortcode.js          # Shortcode generation utility
+│       ├── editor.scss           # Editor-only styles
+│       └── style.scss            # Frontend and editor styles
+│
+├── build/                        # Compiled assets (distributed)
+│   ├── html-sitemap-block/       # Built block files
+│   └── blocks-manifest.php       # WordPress block manifest
+│
+├── .wordpress-org/               # WordPress.org assets
+│   ├── banner-*.png              # Plugin directory banners
+│   ├── icon-*.png                # Plugin directory icons
+│   ├── screenshot-*.png          # Plugin directory screenshots
+│   └── blueprints/               # WordPress Playground demos
+│
+├── .github/                      # GitHub configuration
+└── .kiro/                        # Kiro AI assistant configuration
+    └── steering/                 # AI guidance documents
+```
+
+## Code Organization
+
+### PHP Layer
+- Main plugin file handles shortcode registration and processing
+- Admin class handles block registration via `register_block_type()`
+- Security: Direct access prevention with `ABSPATH` check
+- Sanitization: All shortcode attributes sanitized (text, int, int lists)
+
+### JavaScript Layer
+- Block source in `src/html-sitemap-block/`
+- Compiled output in `build/html-sitemap-block/`
+- Block transforms to/from core shortcode block
+- Uses WordPress components for consistent UI
+
+## File Naming Conventions
+
+- PHP files: `kebab-case.php` or `kebab-case.class.php`
+- JS files: `camelCase.js`
+- Style files: `kebab-case.scss`
+- Config files: `kebab-case.json`
+
+## Distribution
+
+Files excluded from distribution (via `.distignore`):
+- `src/` directory (source files)
+- `node_modules/`
+- `.git/` and `.github/`
+- Development configuration files

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,60 @@
+# Technology Stack
+
+## Core Technologies
+
+- **Language**: PHP 5.4+ (plugin core), JavaScript ES6+ (block editor)
+- **Platform**: WordPress 3.7+ (tested up to 6.9)
+- **License**: GPLv2 or later
+
+## Build System
+
+- **Build Tool**: `@wordpress/scripts` (WordPress official build tooling)
+- **Package Manager**: npm
+- **Bundler**: Webpack (via @wordpress/scripts)
+
+## Dependencies
+
+### Runtime Dependencies
+- `@wordpress/block-editor` - Block editor components
+- `@wordpress/blocks` - Block registration and transforms
+- `@wordpress/components` - UI components for block controls
+- `@wordpress/element` - React abstraction layer
+- `@wordpress/icons` - WordPress icon library
+- `@wordpress/i18n` - Internationalization utilities
+
+### Development Dependencies
+- `@wordpress/scripts` - Build, lint, and format tooling
+
+## Common Commands
+
+```bash
+# Development mode with hot reload
+npm start
+
+# Production build
+npm run build
+
+# Create plugin zip for distribution
+npm run plugin-zip
+
+# Code quality
+npm run lint:js        # Lint JavaScript
+npm run lint:css       # Lint CSS/SCSS
+npm run format         # Format code
+
+# Update WordPress packages
+npm run packages-update
+```
+
+## Build Output
+
+- Source files: `src/html-sitemap-block/`
+- Build output: `build/html-sitemap-block/`
+- Manifest: `build/blocks-manifest.php` (generated with `--blocks-manifest` flag)
+
+## WordPress Integration
+
+- Block registration via `registerBlockType()` from `@wordpress/blocks`
+- Shortcode handler: `html_sitemap_shortcode_handler()` in main PHP file
+- Admin functionality: `html-sitemap-admin.class.php`
+- Text domain: `html-sitemap` (for translations)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ For example `2.0` will be used rather than `2.0.0`. Otherwise Semantic Versionin
 ## [Unreleased]
 TBD
 
+## [2.1.1] - 2026-03-30
+
+* Updated typo documenting the `sort_order` default.
+
 ## [2.1] - 2026-03-30
 
 Preview functionality added for WordPress.org plugin directory.

--- a/html-sitemap.php
+++ b/html-sitemap.php
@@ -3,7 +3,7 @@
 Plugin Name: HTML Page Sitemap (Block and Shortcode)
 Plugin URI: http://www.pluginspodcast.com/plugins/html-page-sitemap/
 Description: <a href="https://wordpress.org/plugins/html-sitemap/" target="_blank">HTML Page Sitemap</a> Adds an HTML (Not XML) sitemap of your blog pages (not posts) by using the HTML Sitemap Block or [html_sitemap] shortcode. A plugin from <a href="http://angelo.mandato.com/" target="_blank">Angelo Mandato</a>.
-Version: 2.1
+Version: 2.1.1
 Contributors: Angelo Mandato, Founder and CTO of [Painless Analytics](https://www.painlessanalytics.com)
 Author URI: http://angelo.mandato.com/
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://angelo.mandato.com/contact/
 Tags: html sitemap, sitemap, page, block, shortcode
 Requires at least: 3.7
 Tested up to: 6.9
-Stable tag: 2.1
+Stable tag: 2.1.1
 Requires PHP: 5.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -38,7 +38,7 @@ The following wp_list_pages tag attribute options are supported:
 * `post_type` &mdash; Post type to query for. Default 'page'
 * `post_status` &mdash; Comma-separated list or array of post statuses to include. Default 'publish'
 * `show_date` &mdash; Whether to display the page publish or modified date for each page. Accepts 'modified' or any other value. An empty value hides the date.
-* `sort_column` &mdash; Comma-separated list of column names to sort the pages by. Accepts 'post_author', 'post_date', 'post_title', 'post_name', 'post_modified', 'post_modified_gmt', 'menu_order', 'post_parent', 'ID', 'rand', or 'comment_count'. Default 'post_title'.
+* `sort_column` &mdash; Comma-separated list of column names to sort the pages by. Accepts 'post_author', 'post_date', 'post_title', 'post_name', 'post_modified', 'post_modified_gmt', 'menu_order', 'post_parent', 'ID', 'rand', or 'comment_count'. Default 'menu_order, post_title'.
 * `sort_order` &mdash; 'ASC' or 'DESC'. Default 'ASC'.
 
 Please see documentation for the [`wp_list_pages`](https://codex.wordpress.org/Function_Reference/wp_list_pages) function for reference.
@@ -154,6 +154,10 @@ Install using the [built-in plugin installer](https://codex.wordpress.org/Admini
 4. Preview of Sitemap block in page "Level 1" with child_of set to CURRENT.
 
 == Changelog ==
+
+= 2.1.1 =
+* Released on 2026-04-24
+* Updated typo documenting the `sort_order` default.
 
 = 2.1 =
 * Released on 2026-03-30


### PR DESCRIPTION
* Released on 2026-04-24
* Updated typo documenting the `sort_order` default.