### PR TITLE
Add review prompt notice on WordPress dashboard

### DIFF
--- a/html-sitemap-admin.class.php
+++ b/html-sitemap-admin.class.php
@@ -24,8 +24,48 @@ class HtmlSitemapAdmin {
      * Constructor
      */
     private function __construct() {
-        
+
         add_action('init', [$this, 'init'] );
+        add_action('admin_notices', [$this, 'maybe_show_review_notice']);
+        add_action('wp_ajax_html_sitemap_dismiss_review', [$this, 'dismiss_review_notice']);
+    }
+
+    public function maybe_show_review_notice() {
+        $screen = get_current_screen();
+        if ( ! $screen || $screen->id !== 'dashboard' ) {
+            return;
+        }
+        if ( get_user_meta( get_current_user_id(), 'html_sitemap_review_dismissed', true ) ) {
+            return;
+        }
+        $review_url = 'https://wordpress.org/support/plugin/html-sitemap/reviews/#new-post';
+        $nonce      = wp_create_nonce( 'html_sitemap_dismiss_review' );
+        ?>
+        <div class="notice notice-info is-dismissible html-sitemap-review-notice" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+            <p>
+                <strong><?php esc_html_e( 'Are you enjoying the HTML Page Sitemap plugin?', 'html-sitemap' ); ?></strong>
+                <?php esc_html_e( 'If it\'s been helpful on your site, your review on WordPress.org makes a huge difference — it helps other site owners discover the plugin and encourages continued development.', 'html-sitemap' ); ?>
+                <?php esc_html_e( 'It only takes a minute and means the world to us!', 'html-sitemap' ); ?>
+                &nbsp;&#11088;&nbsp;<a href="<?php echo esc_url( $review_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Click here to leave a review on WordPress.org &rarr;', 'html-sitemap' ); ?></a>
+            </p>
+        </div>
+        <script>
+        jQuery(function($) {
+            $(document).on('click', '.html-sitemap-review-notice .notice-dismiss', function() {
+                $.post(ajaxurl, {
+                    action: 'html_sitemap_dismiss_review',
+                    nonce: $('.html-sitemap-review-notice').data('nonce')
+                });
+            });
+        });
+        </script>
+        <?php
+    }
+
+    public function dismiss_review_notice() {
+        check_ajax_referer( 'html_sitemap_dismiss_review', 'nonce' );
+        update_user_meta( get_current_user_id(), 'html_sitemap_review_dismissed', '1' );
+        wp_die();
     }
 
     public function init() {


### PR DESCRIPTION
Shows a dismissible admin notice on wp-admin/index.php asking users
to leave a review on WordPress.org. Dismissal is stored per-user via
user meta so each admin can independently close it permanently.

https://claude.ai/code/session_0165qcvVgCWdjXuMMRMtTwLf